### PR TITLE
Fix UoW Transaction handling, InMemory clone bugs, and general Code Quality

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "allowPrerelease": false,
-    "rollForward": "latestMinor",
-    "version": "8.0.*"
+    "rollForward": "latestPatch",
+    "version": "8.0.100"
   }
 }

--- a/src/MongoZen/DbContextSession.cs
+++ b/src/MongoZen/DbContextSession.cs
@@ -176,7 +176,7 @@ public abstract class DbContextSession<TDbContext> : IAsyncDisposable
     {
         if (_session != null)
         {
-            if (_session.IsInTransaction)
+            if (_session.IsInTransaction && _ownsSession)
             {
                 try
                 {
@@ -215,13 +215,12 @@ public abstract class DbContextSession<TDbContext> : IAsyncDisposable
 
         if (_session != null && !_session.IsInTransaction)
         {
-            if (_dbContext.Options.Conventions.TransactionSupportBehavior == TransactionSupportBehavior.Simulate)
+            if (_dbContext.Options.Conventions.TransactionSupportBehavior == TransactionSupportBehavior.Throw)
             {
-                _inMemoryTransaction = true;
-                return;
+                throw new InvalidOperationException("MongoDB commits require an active transaction.");
             }
 
-            throw new InvalidOperationException("MongoDB commits require an active transaction.");
+            _inMemoryTransaction = true;
         }
     }
 
@@ -284,13 +283,12 @@ public abstract class DbContextSession<TDbContext> : IAsyncDisposable
 
     private void HandleUnsupportedTransactions()
     {
-        if (_dbContext.Options.Conventions.TransactionSupportBehavior == TransactionSupportBehavior.Simulate)
+        if (_dbContext.Options.Conventions.TransactionSupportBehavior == TransactionSupportBehavior.Throw)
         {
-            _inMemoryTransaction = true;
-            return;
+            throw new InvalidOperationException(
+                "MongoDB transactions require a replica set or sharded cluster. Configure Conventions.TransactionSupportBehavior to Simulate to fall back to a non-transactional unit of work.");
         }
 
-        throw new InvalidOperationException(
-            "MongoDB transactions require a replica set or sharded cluster. Configure Conventions.TransactionSupportBehavior to Simulate to fall back to a non-transactional unit of work.");
+        _inMemoryTransaction = true;
     }
 }

--- a/src/MongoZen/DbSet.cs
+++ b/src/MongoZen/DbSet.cs
@@ -23,19 +23,19 @@ public class DbSet<TEntity> : IDbSet<TEntity>
         _collectionAsQueryable = _collection.AsQueryable();
     }
 
-    public async ValueTask<IEnumerable<TEntity>> QueryAsync(FilterDefinition<TEntity> filter) =>
-        await (await _collection.FindAsync(filter)).ToListAsync();
+    public async ValueTask<IEnumerable<TEntity>> QueryAsync(FilterDefinition<TEntity> filter, CancellationToken cancellationToken = default) =>
+        await (await _collection.FindAsync(filter, cancellationToken: cancellationToken)).ToListAsync(cancellationToken);
 
-    public async ValueTask<IEnumerable<TEntity>> QueryAsync(Expression<Func<TEntity, bool>> filter) =>
-        await (await _collection.FindAsync(Builders<TEntity>.Filter.Where(filter))).ToListAsync();
+    public async ValueTask<IEnumerable<TEntity>> QueryAsync(Expression<Func<TEntity, bool>> filter, CancellationToken cancellationToken = default) =>
+        await (await _collection.FindAsync(Builders<TEntity>.Filter.Where(filter), cancellationToken: cancellationToken)).ToListAsync(cancellationToken);
 
-    public async ValueTask<IEnumerable<TEntity>> QueryAsync(FilterDefinition<TEntity> filter, IClientSessionHandle session) =>
-        await (await _collection.FindAsync(session, filter)).ToListAsync();
+    public async ValueTask<IEnumerable<TEntity>> QueryAsync(FilterDefinition<TEntity> filter, IClientSessionHandle session, CancellationToken cancellationToken = default) =>
+        await (await _collection.FindAsync(session, filter, cancellationToken: cancellationToken)).ToListAsync(cancellationToken);
 
-    public async ValueTask<IEnumerable<TEntity>> QueryAsync(Expression<Func<TEntity, bool>> filter, IClientSessionHandle session) =>
-        await (await _collection.FindAsync(session, Builders<TEntity>.Filter.Where(filter))).ToListAsync();
+    public async ValueTask<IEnumerable<TEntity>> QueryAsync(Expression<Func<TEntity, bool>> filter, IClientSessionHandle session, CancellationToken cancellationToken = default) =>
+        await (await _collection.FindAsync(session, Builders<TEntity>.Filter.Where(filter), cancellationToken: cancellationToken)).ToListAsync(cancellationToken);
 
-    public IEnumerator<TEntity> GetEnumerator() => _collectionAsQueryable.GetEnumerator();
+    public IEnumerator<TEntity> GetEnumerator() => throw new NotSupportedException("Use QueryAsync for asynchronous execution instead of synchronous LINQ evaluation.");
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 

--- a/src/MongoZen/FilterUtils/ExpressionTranslators/FilterRegexElementTranslator.cs
+++ b/src/MongoZen/FilterUtils/ExpressionTranslators/FilterRegexElementTranslator.cs
@@ -43,9 +43,31 @@ public class FilterRegexElementTranslator: FilterElementTranslatorBase
         }
 
         var regexOptions = RegexOptions.None;
-        if (options?.Contains('i') ?? false)
+        if (options != null)
         {
-            regexOptions |= RegexOptions.IgnoreCase;
+            foreach (var ch in options)
+            {
+                if (ch == 'i')
+                {
+                    regexOptions |= RegexOptions.IgnoreCase;
+                }
+                else if (ch == 'm')
+                {
+                    regexOptions |= RegexOptions.Multiline;
+                }
+                else if (ch == 's')
+                {
+                    regexOptions |= RegexOptions.Singleline;
+                }
+                else if (ch == 'x')
+                {
+                    regexOptions |= RegexOptions.IgnorePatternWhitespace;
+                }
+                else
+                {
+                    throw new NotSupportedException($"Regex option '{ch}' is not supported.");
+                }
+            }
         }
 
         var member = Expression.PropertyOrField(param, field);

--- a/src/MongoZen/IDbSet.cs
+++ b/src/MongoZen/IDbSet.cs
@@ -5,11 +5,11 @@ namespace MongoZen;
 
 public interface IDbSet<T> : IQueryable<T>
 {
-    ValueTask<IEnumerable<T>> QueryAsync(FilterDefinition<T> filter);
+    ValueTask<IEnumerable<T>> QueryAsync(FilterDefinition<T> filter, CancellationToken cancellationToken = default);
 
-    ValueTask<IEnumerable<T>> QueryAsync(Expression<Func<T, bool>> filter);
+    ValueTask<IEnumerable<T>> QueryAsync(Expression<Func<T, bool>> filter, CancellationToken cancellationToken = default);
 
-    ValueTask<IEnumerable<T>> QueryAsync(FilterDefinition<T> filter, IClientSessionHandle session);
+    ValueTask<IEnumerable<T>> QueryAsync(FilterDefinition<T> filter, IClientSessionHandle session, CancellationToken cancellationToken = default);
 
-    ValueTask<IEnumerable<T>> QueryAsync(Expression<Func<T, bool>> filter, IClientSessionHandle session);
+    ValueTask<IEnumerable<T>> QueryAsync(Expression<Func<T, bool>> filter, IClientSessionHandle session, CancellationToken cancellationToken = default);
 }

--- a/src/MongoZen/IMutableDbSet.cs
+++ b/src/MongoZen/IMutableDbSet.cs
@@ -14,7 +14,7 @@ public interface IMutableDbSet<T> : IDbSet<T>
 
     IEnumerable<T> GetUpdated();
 
-    Task CommitAsync(TransactionContext transaction); // eventually used in SaveChanges()
+    Task CommitAsync(TransactionContext transaction, CancellationToken cancellationToken = default); // eventually used in SaveChanges()
 
     /// <summary>
     /// Clears all tracked adds, removes, and updates.

--- a/src/MongoZen/InMemoryDbSet.cs
+++ b/src/MongoZen/InMemoryDbSet.cs
@@ -29,14 +29,14 @@ public class InMemoryDbSet<T> : IDbSet<T>
     {
     }
 
-    public ValueTask<IEnumerable<T>> QueryAsync(FilterDefinition<T> filter)
+    public ValueTask<IEnumerable<T>> QueryAsync(FilterDefinition<T> filter, CancellationToken cancellationToken = default)
     {
         var expr = _translator.Translate(filter);
         var result = _items.AsQueryable().Where(expr).Select(Clone).ToList();
         return ValueTask.FromResult((IEnumerable<T>)result);
     }
 
-    public ValueTask<IEnumerable<T>> QueryAsync(Expression<Func<T, bool>> filter)
+    public ValueTask<IEnumerable<T>> QueryAsync(Expression<Func<T, bool>> filter, CancellationToken cancellationToken = default)
     {
         var result = _items.AsQueryable()
             .Where(filter)
@@ -47,13 +47,13 @@ public class InMemoryDbSet<T> : IDbSet<T>
         return ValueTask.FromResult<IEnumerable<T>>(result);
     }
 
-    public ValueTask<IEnumerable<T>> QueryAsync(FilterDefinition<T> filter, IClientSessionHandle session)
-        => QueryAsync(filter);
+    public ValueTask<IEnumerable<T>> QueryAsync(FilterDefinition<T> filter, IClientSessionHandle session, CancellationToken cancellationToken = default)
+        => QueryAsync(filter, cancellationToken);
 
-    public ValueTask<IEnumerable<T>> QueryAsync(Expression<Func<T, bool>> filter, IClientSessionHandle session)
-        => QueryAsync(filter);
+    public ValueTask<IEnumerable<T>> QueryAsync(Expression<Func<T, bool>> filter, IClientSessionHandle session, CancellationToken cancellationToken = default)
+        => QueryAsync(filter, cancellationToken);
 
-    public IEnumerator<T> GetEnumerator() => _items.AsQueryable().GetEnumerator();
+    public IEnumerator<T> GetEnumerator() => throw new NotSupportedException("Use QueryAsync for asynchronous execution instead of synchronous LINQ evaluation.");
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 

--- a/src/MongoZen/MutableDbSet.cs
+++ b/src/MongoZen/MutableDbSet.cs
@@ -184,7 +184,7 @@ public class MutableDbSet<TEntity> : IMutableDbSet<TEntity>
                 .ToList();
 
             var filter = Builders<TEntity>.Filter.In(_idFieldName, ids);
-            await collection.DeleteManyAsync(filter, cancellationToken);
+            await collection.DeleteManyAsync(filter, cancellationToken: cancellationToken);
         }
     }
 
@@ -255,7 +255,7 @@ public class MutableDbSet<TEntity> : IMutableDbSet<TEntity>
                 .ToList();
 
             var filter = Builders<TEntity>.Filter.In(_idFieldName, ids);
-            await collection.DeleteManyAsync(session, filter, cancellationToken);
+            await collection.DeleteManyAsync(session, filter, cancellationToken: cancellationToken);
         }
     }
 

--- a/src/MongoZen/MutableDbSet.cs
+++ b/src/MongoZen/MutableDbSet.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Text.Json;
 using MongoDB.Driver;
 
 // ReSharper disable ComplexConditionExpression
@@ -11,6 +12,7 @@ public class MutableDbSet<TEntity> : IMutableDbSet<TEntity>
     private readonly Conventions _conventions;
     private readonly IDbSet<TEntity> _baseSet;
     private readonly Func<TEntity, object?> _idAccessor;
+    private readonly string _idFieldName;
 
     private readonly List<TEntity> _added = [];
     private readonly List<TEntity> _removed = [];
@@ -21,6 +23,7 @@ public class MutableDbSet<TEntity> : IMutableDbSet<TEntity>
         _baseSet = baseSet;
         _conventions = conventions ?? new();
         _idAccessor = EntityIdAccessor<TEntity>.GetAccessor(_conventions.IdConvention);
+        _idFieldName = _conventions.IdConvention.ResolveIdProperty<TEntity>()?.Name ?? "_id";
     }
 
     public void Add(TEntity entity) => _added.Add(entity);
@@ -35,7 +38,7 @@ public class MutableDbSet<TEntity> : IMutableDbSet<TEntity>
 
     public IEnumerable<TEntity> GetUpdated() => _updated;
 
-    public async Task CommitAsync(TransactionContext transaction)
+    public async Task CommitAsync(TransactionContext transaction, CancellationToken cancellationToken = default)
     {
         if (!transaction.IsActive)
         {
@@ -50,18 +53,18 @@ public class MutableDbSet<TEntity> : IMutableDbSet<TEntity>
                     throw new InvalidOperationException("In-memory commits require an in-memory transaction.");
                 }
 
-                await InternalCommitAsync(memSet);
+                await InternalCommitAsync(memSet, cancellationToken);
                 break;
             case DbSet<TEntity> mongoSet:
                 if (transaction.IsInMemoryTransaction)
                 {
                     if (transaction.Session != null)
                     {
-                        await InternalCommitAsync(mongoSet, transaction.Session);
+                        await InternalCommitAsync(mongoSet, transaction.Session, cancellationToken);
                     }
                     else
                     {
-                        await InternalCommitAsync(mongoSet);
+                        await InternalCommitAsync(mongoSet, cancellationToken);
                     }
 
                     break;
@@ -77,7 +80,7 @@ public class MutableDbSet<TEntity> : IMutableDbSet<TEntity>
                     throw new InvalidOperationException("MongoDB commits require an active transaction.");
                 }
 
-                await InternalCommitAsync(mongoSet, transaction.Session);
+                await InternalCommitAsync(mongoSet, transaction.Session, cancellationToken);
                 break;
             default:
                 throw new NotSupportedException($"The type {_baseSet.GetType()} is not supported.");
@@ -96,7 +99,7 @@ public class MutableDbSet<TEntity> : IMutableDbSet<TEntity>
     }
 
     // IQueryable passthrough
-    public IEnumerator<TEntity> GetEnumerator() => _baseSet.GetEnumerator();
+    public IEnumerator<TEntity> GetEnumerator() => throw new NotSupportedException("Use QueryAsync for asynchronous execution instead of synchronous LINQ evaluation.");
 
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
@@ -106,36 +109,36 @@ public class MutableDbSet<TEntity> : IMutableDbSet<TEntity>
 
     public IQueryProvider Provider => _baseSet.Provider;
 
-    public ValueTask<IEnumerable<TEntity>> QueryAsync(FilterDefinition<TEntity> filter) => _baseSet.QueryAsync(filter);
+    public ValueTask<IEnumerable<TEntity>> QueryAsync(FilterDefinition<TEntity> filter, CancellationToken cancellationToken = default) => _baseSet.QueryAsync(filter, cancellationToken);
 
-    public ValueTask<IEnumerable<TEntity>> QueryAsync(Expression<Func<TEntity, bool>> filter) => _baseSet.QueryAsync(filter);
+    public ValueTask<IEnumerable<TEntity>> QueryAsync(Expression<Func<TEntity, bool>> filter, CancellationToken cancellationToken = default) => _baseSet.QueryAsync(filter, cancellationToken);
 
-    public ValueTask<IEnumerable<TEntity>> QueryAsync(FilterDefinition<TEntity> filter, IClientSessionHandle session)
-        => _baseSet.QueryAsync(filter, session);
+    public ValueTask<IEnumerable<TEntity>> QueryAsync(FilterDefinition<TEntity> filter, IClientSessionHandle session, CancellationToken cancellationToken = default)
+        => _baseSet.QueryAsync(filter, session, cancellationToken);
 
-    public ValueTask<IEnumerable<TEntity>> QueryAsync(Expression<Func<TEntity, bool>> filter, IClientSessionHandle session)
-        => _baseSet.QueryAsync(filter, session);
+    public ValueTask<IEnumerable<TEntity>> QueryAsync(Expression<Func<TEntity, bool>> filter, IClientSessionHandle session, CancellationToken cancellationToken = default)
+        => _baseSet.QueryAsync(filter, session, cancellationToken);
 
-    private async Task InternalCommitAsync(DbSet<TEntity> mongoSet)
+    private async Task InternalCommitAsync(DbSet<TEntity> mongoSet, CancellationToken cancellationToken = default)
     {
         var collection = mongoSet.Collection;
 
         foreach (var entity in _updated)
         {
-            if (!entity.TryGetId(out var id))
+            if (!entity.TryGetId(_idAccessor, out var id))
             {
                 continue;
             }
 
-            var filter = Builders<TEntity>.Filter.Eq("_id", id);
-            var result = await collection.ReplaceOneAsync(filter, entity);
+            var filter = Builders<TEntity>.Filter.Eq(_idFieldName, id);
+            var result = await collection.ReplaceOneAsync(filter, entity, cancellationToken: cancellationToken);
 
             // this means we are missing this document, so we mimic MongoDB driver and add it
             if (result.MatchedCount != 1 || result.ModifiedCount != 1)
             {
                 var existing = _added.FirstOrDefault(addItem =>
                     addItem is not null
-                    && addItem.TryGetId(out var addId)
+                    && addItem.TryGetId(_idAccessor, out var addId)
                     && addId!.Equals(id));
 
                 // so we "override" the added item with updated item
@@ -156,19 +159,19 @@ public class MutableDbSet<TEntity> : IMutableDbSet<TEntity>
                 .GroupBy(doc =>
                 {
                     ArgumentNullException.ThrowIfNull(doc);
-                    return doc.GetId();
+                    return doc.GetId(_idAccessor);
                 });
             var uniqueDocs = addedWithUniqueIds
                 .Select(x => x.FirstOrDefault())
                 .Where(x => x != null)
                 .Cast<TEntity>();
 
-            await collection.InsertManyAsync(uniqueDocs);
+            await collection.InsertManyAsync(uniqueDocs, cancellationToken: cancellationToken);
 
             foreach (var docGroup in addedWithUniqueIds.Where(group => group.Count() > 1))
             {
                 var replacementDoc = docGroup.Last();
-                await collection.ReplaceOneAsync(Builders<TEntity>.Filter.Eq("_id", docGroup.Key), replacementDoc);
+                await collection.ReplaceOneAsync(Builders<TEntity>.Filter.Eq(_idFieldName, docGroup.Key), replacementDoc, cancellationToken: cancellationToken);
             }
         }
 
@@ -176,16 +179,16 @@ public class MutableDbSet<TEntity> : IMutableDbSet<TEntity>
         {
             var ids = _removed
                 .Where(e => e is not null)
-                .Select(e => e!.GetId())
+                .Select(e => e!.GetId(_idAccessor))
                 .Where(id => id != null)
                 .ToList();
 
-            var filter = Builders<TEntity>.Filter.In("_id", ids);
-            await collection.DeleteManyAsync(filter);
+            var filter = Builders<TEntity>.Filter.In(_idFieldName, ids);
+            await collection.DeleteManyAsync(filter, cancellationToken);
         }
     }
 
-    private async Task InternalCommitAsync(DbSet<TEntity> mongoSet, IClientSessionHandle session)
+    private async Task InternalCommitAsync(DbSet<TEntity> mongoSet, IClientSessionHandle session, CancellationToken cancellationToken = default)
     {
         var collection = mongoSet.Collection;
 
@@ -197,8 +200,8 @@ public class MutableDbSet<TEntity> : IMutableDbSet<TEntity>
                 continue;
             }
 
-            var filter = Builders<TEntity>.Filter.Eq("_id", id);
-            var result = await collection.ReplaceOneAsync(session, filter, entity);
+            var filter = Builders<TEntity>.Filter.Eq(_idFieldName, id);
+            var result = await collection.ReplaceOneAsync(session, filter, entity, cancellationToken: cancellationToken);
 
             // document not found — queue it for insert
             if (result.MatchedCount == 0)
@@ -234,12 +237,12 @@ public class MutableDbSet<TEntity> : IMutableDbSet<TEntity>
                 .Where(x => x != null)
                 .Cast<TEntity>();
 
-            await collection.InsertManyAsync(session, uniqueDocs);
+            await collection.InsertManyAsync(session, uniqueDocs, cancellationToken: cancellationToken);
 
             foreach (var docGroup in addedWithUniqueIds.Where(group => group.Count() > 1))
             {
                 var replacementDoc = docGroup.Last();
-                await collection.ReplaceOneAsync(session, Builders<TEntity>.Filter.Eq("_id", docGroup.Key), replacementDoc);
+                await collection.ReplaceOneAsync(session, Builders<TEntity>.Filter.Eq(_idFieldName, docGroup.Key), replacementDoc, cancellationToken: cancellationToken);
             }
         }
 
@@ -251,12 +254,12 @@ public class MutableDbSet<TEntity> : IMutableDbSet<TEntity>
                     $"Object of type {typeof(TEntity).Name} doesn't expose an Id."))
                 .ToList();
 
-            var filter = Builders<TEntity>.Filter.In("_id", ids);
-            await collection.DeleteManyAsync(session, filter);
+            var filter = Builders<TEntity>.Filter.In(_idFieldName, ids);
+            await collection.DeleteManyAsync(session, filter, cancellationToken);
         }
     }
 
-    private Task InternalCommitAsync(InMemoryDbSet<TEntity> memSet)
+    private Task InternalCommitAsync(InMemoryDbSet<TEntity> memSet, CancellationToken cancellationToken = default)
     {
         foreach (var entity in _added)
         {
@@ -266,7 +269,7 @@ public class MutableDbSet<TEntity> : IMutableDbSet<TEntity>
                 memSet.Collection.Remove(existing);
             }
 
-            memSet.Collection.Add(entity);
+            memSet.Collection.Add(Clone(entity));
         }
 
         foreach (var entity in _removed)
@@ -289,7 +292,7 @@ public class MutableDbSet<TEntity> : IMutableDbSet<TEntity>
             if (existing != null)
             {
                 memSet.Collection.Remove(existing);
-                memSet.Collection.Add(entity);
+                memSet.Collection.Add(Clone(entity));
             }
         }
 
@@ -308,5 +311,11 @@ public class MutableDbSet<TEntity> : IMutableDbSet<TEntity>
         }
 
         return Task.CompletedTask;
+    }
+
+    private static TEntity Clone(TEntity source)
+    {
+        var json = JsonSerializer.Serialize(source);
+        return JsonSerializer.Deserialize<TEntity>(json)!;
     }
 }

--- a/src/MongoZen/TransactionSupportBehavior.cs
+++ b/src/MongoZen/TransactionSupportBehavior.cs
@@ -3,12 +3,12 @@ namespace MongoZen;
 public enum TransactionSupportBehavior
 {
     /// <summary>
-    /// Throw when MongoDB does not support transactions.
-    /// </summary>
-    Throw,
-
-    /// <summary>
     /// Simulate the unit of work without MongoDB transactions.
     /// </summary>
     Simulate,
+
+    /// <summary>
+    /// Throw when MongoDB does not support transactions.
+    /// </summary>
+    Throw,
 }

--- a/tests/MongoZen.Tests/DbContextSessionTests.cs
+++ b/tests/MongoZen.Tests/DbContextSessionTests.cs
@@ -1,0 +1,119 @@
+using MongoDB.Driver;
+using MongoZen;
+
+namespace MongoZen.Tests;
+
+public class DbContextSessionTests : IntegrationTestBase
+{
+    private class User
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+
+        public string Name { get; set; } = string.Empty;
+    }
+
+    private class TestDbContext : DbContext
+    {
+        public TestDbContext(DbContextOptions options)
+            : base(options)
+        {
+        }
+
+        public IDbSet<User> Users { get; set; } = null!;
+    }
+
+    private sealed class TestDbContextSession : DbContextSession<TestDbContext>
+    {
+        public TestDbContextSession(TestDbContext dbContext, bool startTransaction = true)
+            : base(dbContext, startTransaction)
+        {
+        }
+
+        public void ExposeEnsureTransactionActive() => EnsureTransactionActive();
+    }
+
+    [Fact]
+    public async Task Constructor_StartsTransaction()
+    {
+        var ctx = new TestDbContext(new DbContextOptions());
+        await using var session = new TestDbContextSession(ctx);
+
+        Assert.True(session.Transaction.IsActive);
+        Assert.True(session.Transaction.IsInMemoryTransaction);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_ClearsSession()
+    {
+        var ctx = new TestDbContext(new DbContextOptions());
+        var session = new TestDbContextSession(ctx);
+
+        await session.DisposeAsync();
+
+        Assert.Null(session.ClientSession);
+        Assert.False(session.Transaction.IsActive);
+    }
+
+    [Fact]
+    public async Task AbortTransactionAsync_SetsIsActiveToFalse_ForInMemory()
+    {
+        var ctx = new TestDbContext(new DbContextOptions());
+        await using var session = new TestDbContextSession(ctx);
+
+        Assert.True(session.Transaction.IsActive);
+        await session.AbortTransactionAsync();
+
+        Assert.False(session.Transaction.IsActive);
+    }
+
+    [Fact]
+    public async Task CommitTransactionAsync_SetsIsActiveToFalse_ForInMemory()
+    {
+        var ctx = new TestDbContext(new DbContextOptions());
+        await using var session = new TestDbContextSession(ctx);
+
+        Assert.True(session.Transaction.IsActive);
+        await session.CommitTransactionAsync();
+
+        Assert.False(session.Transaction.IsActive);
+    }
+
+    [Fact]
+    public async Task UseSession_WithActiveTransaction_Succeeds()
+    {
+        var ctx = new TestDbContext(new DbContextOptions(Database!));
+        await using var session = new TestDbContextSession(ctx, startTransaction: false);
+
+        using var clientSession = await Client.StartSessionAsync();
+        clientSession.StartTransaction();
+
+        session.UseSession(clientSession);
+
+        Assert.True(session.Transaction.IsActive);
+        Assert.NotNull(session.ClientSession);
+
+        await session.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task UseSession_WithoutActiveTransaction_Throws()
+    {
+        var ctx = new TestDbContext(new DbContextOptions(Database!));
+        await using var session = new TestDbContextSession(ctx, startTransaction: false);
+
+        using var clientSession = await Client.StartSessionAsync();
+
+        Assert.Throws<InvalidOperationException>(() => session.UseSession(clientSession));
+    }
+
+    [Fact]
+    public async Task EnsureTransactionActive_ThrowsAfterCommit()
+    {
+        var ctx = new TestDbContext(new DbContextOptions());
+        await using var session = new TestDbContextSession(ctx);
+
+        await session.CommitTransactionAsync();
+
+        Assert.Throws<InvalidOperationException>(() => session.ExposeEnsureTransactionActive());
+    }
+}

--- a/tests/MongoZen.Tests/TransactionSupportBehaviorTests.cs
+++ b/tests/MongoZen.Tests/TransactionSupportBehaviorTests.cs
@@ -73,7 +73,7 @@ public class TransactionSupportBehaviorTests : IntegrationTestBase
     {
         var conventions = new Conventions { TransactionSupportBehavior = TransactionSupportBehavior.Simulate };
         var ctx = new TestDbContext(new DbContextOptions(Database!, conventions));
-        using var session = new TestDbContextSession(ctx);
+        await using var session = new TestDbContextSession(ctx);
 
         session.Users.Add(new User { Id = "2", Name = "Bob" });
 

--- a/tests/MongoZen.Tests/TransactionTests.cs
+++ b/tests/MongoZen.Tests/TransactionTests.cs
@@ -66,7 +66,7 @@ public class TransactionTests : IntegrationTestBase
     public async Task SaveChanges_ImplicitTransaction_InMemory()
     {
         var ctx = new TestDbContext(new DbContextOptions());
-        using var session = new TestDbContextSession(ctx);
+        await using var session = new TestDbContextSession(ctx);
 
         session.Users.Add(new User { Id = "1", Name = "Alice" });
 
@@ -80,7 +80,7 @@ public class TransactionTests : IntegrationTestBase
     public async Task Transaction_Commits_Changes_On_SaveChanges()
     {
         var ctx = new TestDbContext(new DbContextOptions(Database!));
-        using var session = new TestDbContextSession(ctx);
+        await using var session = new TestDbContextSession(ctx);
 
         session.Users.Add(new User { Id = "1", Name = "Alice" });
 


### PR DESCRIPTION
Updates to MongoZen to fix transaction implementations and various functional bugs and code quality issues:
    
    *   Fixes `DbContextSession.cs` so that exceptions are no longer suppressed on abort.
    *   Fixes `DbContextSession.cs` so it simulates gracefully by default.
    *   Fixes direct reference bugs in `MutableDbSet.cs` by deep cloning for `InMemoryDbSet`.
    *   Replaces hardcoded `_id` with a dynamically resolved property.
    *   Throws `NotSupportedException` in synchronous `GetEnumerator` implementations.
    *   Adds `CancellationToken` support in DB Sets.
    *   Fixes Regex parsing options (`m`, `s`, `x`) in filtering.
    *   Updates unit test dispose (`await using`).
    *   Adds lifecycle unit tests for `DbContextSession`.

---
*PR created automatically by Jules for task [7902486137196413438](https://jules.google.com/task/7902486137196413438) started by @myarichuk*