### PR TITLE
ci: Refactor CI/CD to generate release without required tags

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -78,3 +78,4 @@ jobs:
           generateReleaseNotes: true
           artifacts: "./package/*.nupkg,./package/*.snupkg"
           token: ${{ github.token }}
+          commit: ${{ github.sha }}

--- a/.github/workflows/on-merge-pr.yml
+++ b/.github/workflows/on-merge-pr.yml
@@ -56,9 +56,6 @@ jobs:
           path: |
             ./package/*.nupkg
             ./package/*.snupkg
-      - uses: rickstaa/action-create-tag@v1
-        with:
-          tag: v${{ steps.gitversion.outputs.AssemblySemVer }}
     outputs:
       tag: v${{ steps.gitversion.outputs.AssemblySemVer }}
 
@@ -77,8 +74,8 @@ jobs:
       - name: Publish to NuGet
         run: dotnet nuget push ./*.nupkg  -s https://api.nuget.org/v3/index.json  -k ${{ secrets.NUGET_TOKEN }}
 
-  changelog-release:
-    name: Update Changelog & Release
+  release:
+    name: Create Release
     runs-on: ubuntu-latest
     needs: [build-and-pack]
     steps:
@@ -93,19 +90,6 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: nupkg
-      - name: Update CHANGELOG
-        id: changelog
-        uses: Requarks/changelog-action@v1
-        with:
-          token: ${{ github.token }}
-          tag: ${{needs.build-and-pack.outputs.tag}}
-          excludeTypes: build,docs,other,style
-          writeToFile: true
-          changelogFilePath: CHANGELOG.md
-          includeRefIssues: true
-          useGitmojis: true
-          includeInvalidCommits: false
-          reverseOrder: false
 
       - name: Create Release
         uses: ncipollo/release-action@v1
@@ -113,14 +97,8 @@ jobs:
           allowUpdates: true
           draft: false
           name: ${{needs.build-and-pack.outputs.tag}}
-          body: ${{ steps.changelog.outputs.changes }}
           token: ${{ github.token }}
           tag: ${{needs.build-and-pack.outputs.tag}}
           artifacts: "*.nupkg, *.snupkg"
-      - name: Commit CHANGELOG.md
-        run: |
-            git config --local user.email "action@github.com"
-            git config --local user.name "GitHub Action"
-            git add CHANGELOG.md
-            git commit -m "chore(changelog): update changelog [skip ci]" || echo "No changes to commit"
-            git push origin main
+          generateReleaseNotes: true
+          commit: ${{ github.sha }}


### PR DESCRIPTION
Refactors the CI workflows in `.github/workflows` to generate releases without explicitly needing previously generated git tags.

Removes `rickstaa/action-create-tag` and replaces `Requarks/changelog-action` logic with GitHub's native `generateReleaseNotes: true` alongside specifying `commit: ${{ github.sha }}` in `ncipollo/release-action@v1`.

---
*PR created automatically by Jules for task [277878937461096616](https://jules.google.com/task/277878937461096616) started by @myarichuk*